### PR TITLE
Fixed line number in skip pointer list to start from 0 instead of 1

### DIFF
--- a/M2/InvertedIndex.py
+++ b/M2/InvertedIndex.py
@@ -199,7 +199,7 @@ class InvertedIndex:
         print("Adding skip list to splitted index")
         for splitIndexFileName in splittedIndexFiles:
             data = loadInvertedIndexFromFile(splitIndexFileName)
-            tokenMap = {token: (i+1) for i, token in enumerate(data.keys())}
+            tokenMap = {token: i for i, token in enumerate(data.keys())}
             with open(splitIndexFileName, 'a') as f:
                 f.write(json.dumps(tokenMap))
 


### PR DESCRIPTION
Fixed line numbers.
Earlier, line numbers in the skiplist started from 1 but now they start from 0.

Made this change since all other collaborators' code expect line numbers starting from 1.