### PR TITLE
Fixed inverted index offloading after end of for loop

### DIFF
--- a/M2/assignment3_m1.py
+++ b/M2/assignment3_m1.py
@@ -64,6 +64,9 @@ def process_data(file_names):
         if batch_size_processed >= BATCH_SIZE:
             inverted_index.offloadIndex()
             batch_size_processed = 0
+    if batch_size_processed != 0:
+        inverted_index.offloadIndex()
+        batch_size_processed = 0
     print("Processed {} documents".format(docID))
     store_docID_wordcount_dict()
     inverted_index.mergeInvertedIndexFiles()


### PR DESCRIPTION
When the code exits the for loop after looping through all the files, sometimes we still have some files from the most recent batch which haven't been offloaded to hard disk. Because of this bug, we were missing some datapoints in the inverted index.

This commit fixes that.